### PR TITLE
Resolve cObject variables in per-file includeCSS blocks, set request on cObj

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -23,6 +23,7 @@ namespace WapplerSystems\WsScss\Hooks;
  ***************************************************************/
 
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use ScssPhp\ScssPhp\Exception\SassException;
 use ScssPhp\ScssPhp\OutputStyle;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
@@ -74,24 +75,7 @@ class RenderPreProcessorHook
 
         $setup = $GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.typoscript')->getSetupArray();
         if (\is_array($setup['plugin.']['tx_wsscss.']['variables.'] ?? null)) {
-
-            $variables = $setup['plugin.']['tx_wsscss.']['variables.'];
-
-            $parsedTypoScriptVariables = [];
-
-            if ($this->contentObjectRenderer === null) {
-                $this->contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-            }
-
-            foreach ($variables as $variable => $variableValue) {
-                if (array_key_exists($variable . '.', $variables)) {
-                    $content = $this->contentObjectRenderer->cObjGetSingle($variables[$variable], $variables[$variable . '.']);
-                    $parsedTypoScriptVariables[$variable] = $content;
-                } elseif (!str_ends_with($variable, '.')) {
-                    $parsedTypoScriptVariables[$variable] = $variableValue;
-                }
-            }
-            $this->variables = $parsedTypoScriptVariables;
+            $this->variables = $this->parseTypoScriptVariables($setup['plugin.']['tx_wsscss.']['variables.']);
         }
 
         /** @var ResourceFactory $resourceFactory */
@@ -138,7 +122,7 @@ class RenderPreProcessorHook
                                 $outputStyle = OutputStyle::COMPRESSED;
                             }
                         }
-                        $variables = array_filter($subConf['variables.'] ?? []);
+                        $variables = array_filter($this->parseTypoScriptVariables($subConf['variables.'] ?? []));
                         $inlineOutput = $this->parseBooleanSetting($setup['page.']['includeCSS.'][$key . '.']['inlineOutput'] ?? false, false);
                     }
                 }
@@ -186,6 +170,49 @@ class RenderPreProcessorHook
             }
         }
         $params['cssFiles'] = $cssFiles;
+    }
+
+    /**
+     * Flattens a TypoScript variables array into plain SCSS variable values.
+     *
+     * A variable may either be a plain value (`myVar = 20px`) or a content
+     * object (`myVar = TEXT` + `myVar.value = 20px`). The latter arrives as two
+     * keys -- the object name and a `myVar.` sub-array -- and has to be rendered
+     * before it can be handed to the compiler. Sub-arrays that are left over
+     * are dropped: they would end up in Compiler::compileFile(), where
+     * implode() on the variables array triggers an "Array to string conversion"
+     * warning and, with TYPO3's error handler, a 500 in the frontend.
+     */
+    private function parseTypoScriptVariables(array $variables): array
+    {
+        $parsedVariables = [];
+
+        foreach ($variables as $variable => $variableValue) {
+            if (array_key_exists($variable . '.', $variables)) {
+                $parsedVariables[$variable] = $this->getContentObjectRenderer()
+                    ->cObjGetSingle($variables[$variable], $variables[$variable . '.']);
+            } elseif (!str_ends_with($variable, '.')) {
+                $parsedVariables[$variable] = $variableValue;
+            }
+        }
+
+        return $parsedVariables;
+    }
+
+    private function getContentObjectRenderer(): ContentObjectRenderer
+    {
+        if ($this->contentObjectRenderer === null) {
+            $this->contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        }
+
+        // cObjGetSingle() ends up in ContentObjectRenderer::getRequest(), which falls back to
+        // $GLOBALS['TYPO3_REQUEST'] with a deprecation notice in v14 and loses that fallback in
+        // v15. Assign on every access -- the hook instance can outlive a single request.
+        if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface) {
+            $this->contentObjectRenderer->setRequest($GLOBALS['TYPO3_REQUEST']);
+        }
+
+        return $this->contentObjectRenderer;
     }
 
     private function parseBooleanSetting(string $value, bool $defaultValue): bool


### PR DESCRIPTION
Two bugs in the TypoScript variables handling of `RenderPreProcessorHook`, both found while verifying #98 (which was already fixed in 14.0.4 and is now closed).

## 1. cObject variables in a per-file `includeCSS` block cause a frontend 500

There are two variable paths, and only one of them resolved content objects:

- **global** (`plugin.tx_wsscss.variables`) — the loop rendered `myVar = TEXT` + `myVar.value = …` via `cObjGetSingle()` and skipped keys with a trailing dot → flat array.
- **per file** (`page.includeCSS.<key>.variables`) — `array_filter($subConf['variables.'] ?? [])`, i.e. the TypoScript array **verbatim**. The `myVar.` sub-array survived, went through `array_merge()` into `$mergedVars` and hit `implode(',', $variables)` in `Compiler::compileFile()`:

```
PHP Warning: Array to string conversion in …/ws-scss/Classes/Compiler.php line 83
```

TYPO3's error handler turns that warning into an exception, so the frontend returns HTTP 500.

This is easy to hit, because copying the global block per file is the documented way to scope variables to one file — and t3bootstrap does exactly that (`main.variables < plugin.tx_wsscss.variables` in its `head.typoscript`). Any cObject variable therefore takes the whole frontend down.

Proof from a debug dump inside one request on 14.1.0, with `cobj-test = TEXT` / `cobj-test.value = 3px` configured:

```
array_keys in $this->variables (global, flattened) => []
array_keys in $variables       (per-file, raw)     => ['cobj-test.']
```

Both paths now go through a shared `parseTypoScriptVariables()`.

## 2. `ContentObjectRenderer` had no request → breaks on v15

The renderer was created with `makeInstance()` and never given a request. Every `cObjGetSingle()` call goes `getContentObject()` → `getRequest()`, which in v14 falls back to `$GLOBALS['TYPO3_REQUEST']` and logs:

```
Fallback to $GLOBALS['TYPO3_REQUEST'] in ContentObjectRenderer::getRequest() is deprecated
since TYPO3 v14 and will be removed in TYPO3 v15. Call setRequest() after object instantiation.
```

Confirmed in the deprecation log on every request that renders a cObject variable. Since the fallback disappears in v15, cObject variables would break there. `setRequest()` is now called on every access rather than once at creation, because the hook instance can outlive a single request.

## Verification

TYPO3 14.3.6, PHP 8.5.5, scssphp 2.1.0, real site (t3bootstrap 14).

Before — frontend HTTP 500 as soon as a cObject variable is configured. After, with `cobj-test = TEXT` / `.value = 3px`, a nested `COA` (`10 = TEXT`/`10.value = 7`, `20 = TEXT`/`20.value = px`), a plain value and an empty value all set at once, this is what reaches the compiler:

```
nested keys left in mergedVars => []
cobj-test   => 3px
cobj-nested => 7px
plain-test  => 11px
empty-test  => ''
```

- frontend HTTP 200, no entries in the error log
- zero `ContentObjectRenderer::getRequest()` deprecations
- empty values still pass through unchanged (`Compiler::compileFile()` skips them itself, as before)
- **no regression on an unchanged site**: compiled `main.css` is byte-identical with and without the patch — `e5ff4718575342c1ac4671fb9c4838d4`, 336801 bytes, both times
