### PR TITLE
Resolve cObject variables in per-file includeCSS blocks (v13 backport)

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -76,24 +76,7 @@ class RenderPreProcessorHook
 
         $setup = $GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.typoscript')->getSetupArray();
         if (\is_array($setup['plugin.']['tx_wsscss.']['variables.'] ?? null)) {
-
-            $variables = $setup['plugin.']['tx_wsscss.']['variables.'];
-
-            $parsedTypoScriptVariables = [];
-
-            if ($this->contentObjectRenderer === null) {
-                $this->contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-            }
-
-            foreach ($variables as $variable => $variableValue) {
-                if (array_key_exists($variable . '.', $variables)) {
-                    $content = $this->contentObjectRenderer->cObjGetSingle($variables[$variable], $variables[$variable . '.']);
-                    $parsedTypoScriptVariables[$variable] = $content;
-                } elseif (!str_ends_with($variable, '.')) {
-                    $parsedTypoScriptVariables[$variable] = $variableValue;
-                }
-            }
-            $this->variables = $parsedTypoScriptVariables;
+            $this->variables = $this->parseTypoScriptVariables($setup['plugin.']['tx_wsscss.']['variables.']);
         }
 
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
@@ -137,7 +120,7 @@ class RenderPreProcessorHook
                                 $outputStyle = OutputStyle::COMPRESSED;
                             }
                         }
-                        $variables = array_filter($subConf['variables.'] ?? []);
+                        $variables = array_filter($this->parseTypoScriptVariables($subConf['variables.'] ?? []));
                         $inlineOutput = $this->parseBooleanSetting($setup['page.']['includeCSS.'][$key . '.']['inlineOutput'] ?? false, false);
                     }
                 }
@@ -174,6 +157,36 @@ class RenderPreProcessorHook
             }
         }
         $params['cssFiles'] = $cssFiles;
+    }
+
+    /**
+     * Flattens a TypoScript variables array into plain SCSS variable values.
+     *
+     * A variable may either be a plain value (`myVar = 20px`) or a content
+     * object (`myVar = TEXT` + `myVar.value = 20px`). The latter arrives as two
+     * keys -- the object name and a `myVar.` sub-array -- and has to be rendered
+     * before it can be handed to the compiler. Sub-arrays that are left over
+     * are dropped: they would end up in Compiler::compileFile(), where
+     * implode() on the variables array triggers an "Array to string conversion"
+     * warning and, with TYPO3's error handler, a 500 in the frontend.
+     */
+    private function parseTypoScriptVariables(array $variables): array
+    {
+        $parsedVariables = [];
+
+        foreach ($variables as $variable => $variableValue) {
+            if (array_key_exists($variable . '.', $variables)) {
+                if ($this->contentObjectRenderer === null) {
+                    $this->contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+                }
+                $parsedVariables[$variable] = $this->contentObjectRenderer
+                    ->cObjGetSingle($variables[$variable], $variables[$variable . '.']);
+            } elseif (!str_ends_with($variable, '.')) {
+                $parsedVariables[$variable] = $variableValue;
+            }
+        }
+
+        return $parsedVariables;
     }
 
     private function parseBooleanSetting(string $value, bool $defaultValue): bool


### PR DESCRIPTION
Backport of the first half of #105 to `release/v13`. The v13 branch has the same bug: only the global `plugin.tx_wsscss.variables` path resolved content objects, while the per-file `page.includeCSS.<key>.variables` block took the TypoScript array verbatim (`array_filter($subConf['variables.'] ?? [])`, line 140).

A cObject variable (`myVar = TEXT` + `myVar.value = …`) therefore kept its `myVar.` sub-array, which reached `Compiler::compileFile()` and hit `implode(',', $variables)`:

```
PHP Warning: Array to string conversion in …/ws-scss/Classes/Compiler.php line 82
```

TYPO3's error handler turns that into an exception → HTTP 500 in the frontend. It is easy to hit, because copying the global block per file is the documented way to scope variables to a single file, and t3bootstrap does exactly that.

Both paths now share `parseTypoScriptVariables()`.

**Not backported:** the `setRequest()` part of #105. `ContentObjectRenderer::getRequest()` still has an undeprecated `$GLOBALS['TYPO3_REQUEST']` fallback in v13 (only a `@todo` in core), so that change has no effect here and is left out to keep the diff minimal.

## Verification

TYPO3 13.4.29-dev, PHP 8.4.20, scssphp 2.1.0. Driving `renderPreProcessorProc()` with a per-file block containing `cobj-test = TEXT` / `.value = 3px`, a nested `COA` (`10 = TEXT`/`10.value = 7`, `20 = TEXT`/`20.value = px`) and a plain `11px`:

*before*
```
THROWN: TYPO3\CMS\Core\Error\Exception
  PHP Warning: Array to string conversion in …/ws-scss/Classes/Compiler.php line 82
```

*after*
```
.probe {
  padding: 3px;
  margin: 7px;
  gap: 11px;
}
```

No regression on the setups that already worked — global block, per-file plain values, and global cObject all compile to byte-identical CSS with and without the patch (`md5=9222d0fbf812c3ec0f495bea1360b9db` in all six runs).
